### PR TITLE
Error handling

### DIFF
--- a/src/android/MinewTrackerkit.java
+++ b/src/android/MinewTrackerkit.java
@@ -48,7 +48,7 @@ public class MinewTrackerkit extends CordovaPlugin {
   private CallbackContext findCallback;
   private CallbackContext connectCallback;
   private CallbackContext clickCallback;
-  private CallbackContext disconnectCallback;
+  private CallbackContext disconnectCallback; // the subscription callback
   private CallbackContext unbindCallback;
 
   // central tracker manager and list of buttons
@@ -297,7 +297,7 @@ public class MinewTrackerkit extends CordovaPlugin {
     public void onUpdateConnectionState(final boolean success, final TrackerException trackerException) {
       if (connectCallback != null) {
         PluginResult result;
-        // result.setKeepCallback(true); ????
+        // TODO: investigate holding open this callback result.setKeepCallback(true) 
         if (success) {
           myTracker = manager.bindMTTracker(myTracker.getMacAddress());
           result = new PluginResult(PluginResult.Status.OK);

--- a/src/android/MinewTrackerkit.java
+++ b/src/android/MinewTrackerkit.java
@@ -167,6 +167,9 @@ public class MinewTrackerkit extends CordovaPlugin {
       MTTracker trackerToBind = peripherals.get(macAddress);
       myTracker = trackerToBind;
       manager.bindingVerify(trackerToBind, this.connectionCallback);
+    } else {
+      PluginResult result = new PluginResult(PluginResult.Status.ERROR);
+      connectCallback.sendPluginResult(result);
     }
   }
 
@@ -294,6 +297,7 @@ public class MinewTrackerkit extends CordovaPlugin {
     public void onUpdateConnectionState(final boolean success, final TrackerException trackerException) {
       if (connectCallback != null) {
         PluginResult result;
+        // result.setKeepCallback(true); ????
         if (success) {
           myTracker = manager.bindMTTracker(myTracker.getMacAddress());
           result = new PluginResult(PluginResult.Status.OK);
@@ -338,7 +342,6 @@ public class MinewTrackerkit extends CordovaPlugin {
           break;
       }
 
-      // DistanceLevel distance = tracker.getDistance();
     } catch (JSONException e) { // this shouldn't happen
       e.printStackTrace();
     }

--- a/src/ios/MinewTrackerkit.m
+++ b/src/ios/MinewTrackerkit.m
@@ -71,16 +71,21 @@
   NSSet *trackers = [peripherals filteredSetUsingPredicate:predicate];
   NSArray *array = [trackers allObjects];
   // NSLog(@"number of periperhals: %d",[array count]);
-  MTTracker *trackerToBind = [array objectAtIndex:0];
-  [manager bindingVerify:trackerToBind completion:^(BOOL success, NSError *error) {
-    CDVPluginResult *result;
-    if (success) {
-      result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-    } else {
-      result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
-    }
-    [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-  }];
+  NSInteger N = [trackers count];
+  CDVPluginResult *result;
+  if (N < 1) {
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"cant find id"];
+  } else {
+    MTTracker *trackerToBind = [array objectAtIndex:0];
+    [manager bindingVerify:trackerToBind completion:^(BOOL success, NSError *error) {
+      if (success) {
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+      } else {
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"connection failed"];
+      }
+      [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+    }];
+  }
 }
 
 - (void)disconnect:(CDVInvokedUrlCommand *)command {


### PR DESCRIPTION
Updates to catch cases where no tracker with a matching id is found and return these errors to the cordova onFail callbacks.
This should help make our connections more robust with the new buttons and more importantly will prevent crashing errors thrown by the plugin.