### PR TITLE
[1 of 2] Fix crash error when resetting button list

### DIFF
--- a/src/android/MinewTrackerkit.java
+++ b/src/android/MinewTrackerkit.java
@@ -180,20 +180,15 @@ public class MinewTrackerkit extends CordovaPlugin {
       manager.unBindMTTracker(macAddress, new OperationCallback() {
         @Override
         public void onOperation(boolean success, TrackerException mtException) {
-          if (success) {
-            myTracker = null;
-            peripherals = new LinkedHashMap<String, MTTracker>();
-            manager = MTTrackerManager.getInstance(mContext);
-            findCallback = null;
-            connectCallback = null;
-            disconnectCallback = null;
-            clickCallback = null;
-            PluginResult result = new PluginResult(PluginResult.Status.OK);
-            unbindCallback.sendPluginResult(result);
-          } else {
-            PluginResult result = new PluginResult(PluginResult.Status.ERROR);
-            unbindCallback.sendPluginResult(result);
-          }
+          myTracker = null;
+          peripherals = new LinkedHashMap<String, MTTracker>();
+          manager = MTTrackerManager.getInstance(mContext);
+          findCallback = null;
+          connectCallback = null;
+          disconnectCallback = null;
+          clickCallback = null;
+          PluginResult result = new PluginResult(PluginResult.Status.OK);
+          unbindCallback.sendPluginResult(result);
         }
       });
     } else {


### PR DESCRIPTION
- Deals with an error when the user resets the button list while the button is off / out of range or in connecting process. Now the reset will remove existing device and kill running sagas

[1 of 2] cordova-plugin-minew-trackerkit
- https://github.com/seermedical/cordova-plugin-minew-trackerkit/pull/14
- Kill button callbacks even if the disconnection fails. This stops the plugin throwing errors if the callbacks are still active after the device has been removed.

[2 of 2] seer-app
- https://github.com/seermedical/seer-app/pull/605
- Checks that device object exists in the store before running saga tasks that use 'device'. If device does not exist the ongoing event listeners are destroyed.
- TODO: remove / re-add MInew plugin (after first PR is merged to master)