### PR TITLE
Button Flakiness [1 of 2]

### DIFF
--- a/src/ios/MinewTrackerkit.m
+++ b/src/ios/MinewTrackerkit.m
@@ -46,20 +46,19 @@
       MTTracker *tracker = trackers[i];
       NSString *mac = tracker.mac; // mac address
       if ([mac isEqualToString:id]) {
+        NSLog(@"MT: found tracker");
         [peripherals addObject:tracker];
+        [manager stopScan];
         NSMutableDictionary *dictionary = [self asDictionary:tracker];
         [manager bindingVerify:tracker completion:^(BOOL success, NSError *error) {
-          CDVPluginResult *result;
-          if (success) {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
-          } else {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"connection failed"];
-          }
-          [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
-        }];
-      } else {
-        CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"cant find id"];
+        CDVPluginResult *result;
+        if (success) {
+          result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dictionary];
+        } else {
+          result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"connection failed"];
+        }
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
+      }];
       }
     }
   }];
@@ -94,6 +93,7 @@
       // success YES means operate success, else NO.
   }];
   [manager removeTracker:id];
+  [self pluginInitialize];
   CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }


### PR DESCRIPTION
[1 of 2] Plugin change for iOS
[2 of 2] seer-app change (mainly to deviceSaga) https://github.com/seermedical/seer-app/pull/671

There was an issue with finding the saved button on iOS only caused by this 'find' function not working as intended (NB connect is used when the button has already been scanned, find is used when the button may not have been scanned yet).

- Fixed find function by stopping the scan once the correct id is located then initiating the connection in the usual way

- Also a fix that enables a proper reset on button disconnection by re-initialising global variables